### PR TITLE
add api-key to preview urls (this fixes #19)

### DIFF
--- a/collective/embedly/browser/__init__.py
+++ b/collective/embedly/browser/__init__.py
@@ -1,0 +1,8 @@
+from Products.Five.browser import BrowserView
+from collective.embedly.transform import get_embedly_settings
+
+
+class EmbedlyPlugin(BrowserView):
+
+    def api_key(self):
+        return get_embedly_settings('api_key')

--- a/collective/embedly/browser/configure.zcml
+++ b/collective/embedly/browser/configure.zcml
@@ -33,4 +33,12 @@
       directory="plugin"
       />
 
+  <browser:page
+      name="embedly-plugin.html"
+      for="*"
+      class=".EmbedlyPlugin"
+      template="plugin/embedly.pt"
+      permission="zope2.View"
+      />
+
 </configure>

--- a/collective/embedly/browser/plugin/editor_plugin.js
+++ b/collective/embedly/browser/plugin/editor_plugin.js
@@ -7,7 +7,7 @@
                 if (c.isCollapsed() && !a.dom.getParent(c.getNode(), "A"))
                     return;
                 a.windowManager.open({
-                    file: b + "/embedly.pt",
+                    file: b + "/../@@embedly-plugin.html",
                     width: 820 + parseInt(a.getLang("plonelink.delta_width", 0), 10),
                     height: 540 + parseInt(a.getLang("plonelink.delta_height", 0), 10),
                     inline: 1

--- a/collective/embedly/browser/plugin/embedly.pt
+++ b/collective/embedly/browser/plugin/embedly.pt
@@ -7,8 +7,8 @@
   <script type="text/javascript" src="../tiny_mce_popup.js"></script>
   <script type="text/javascript" src="../utils/mctabs.js"></script>
   <script type="text/javascript" src="../utils/form_utils.js"></script>
-  <script type="text/javascript" src="js/embedlylink.js"></script>
-  <link rel="stylesheet" type="text/css" href="css/embedlylink.css" />
+  <script type="text/javascript" src="../++resource++collective.embedly.plugin/js/embedlylink.dev.js"></script>
+  <link rel="stylesheet" type="text/css" href="../++resource++collective.embedly.plugin/css/embedlylink.css" />
 </head>
 <body id="plonelink" class="icons-on">
   <div class="dialog-wrapper" id="content">
@@ -28,6 +28,9 @@
     <div id="general_panel" class="formPanel current">
       <form>
         <input type="hidden" name="href" id="href"/>
+        <input type="hidden" name="apikey" id="apikey"
+            value="some-api-key"
+            tal:attributes="value view/api_key | nothing" />
         <div class="field">
           <label for="externalurl" i18n:translate="">Link URL</label>
           <div class="widget">

--- a/collective/embedly/browser/plugin/js/embedlylink.dev.js
+++ b/collective/embedly/browser/plugin/js/embedlylink.dev.js
@@ -230,6 +230,8 @@ function previewExternalLink() {
     elink = "http://api.embed.ly/1/oembed?format=json";
     params = {};
     params.url = escape(url);
+    var api_key = document.getElementById('apikey').value;
+    params.key = api_key;
     for(var i in params){
       if(params[i])
         elink += '&'+i+'='+params[i];

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+dev
+---
+
+- Add embedly API key to requests in preview mode (this fixes #19)
+  [fRiSi]
+
 2.4 - May 6, 2015
 -----------------
 


### PR DESCRIPTION
required to finally turn the page template (embedly.pt) used as browser:resource (I always wondered why i18n:translate works in there) into a browserview.

i'd suggest a 2.4.1 release as this is just a bugfix