### PR TITLE
Service blacklist

### DIFF
--- a/collective/embedly/browser/controlpanel.py
+++ b/collective/embedly/browser/controlpanel.py
@@ -47,6 +47,12 @@ class EmbedlyControlPanelAdapter(SchemaAdapterBase):
     def setCacheTimeout(self, value):
         self.settings.cache_timeout = value
 
+    def get_blacklist(self):
+        return self.settings.service_blacklist
+
+    def set_blacklist(self, value):
+        self.settings.service_blacklist = value
+
     api_key = property(getAPIKey,
                        setAPIKey)
 
@@ -58,6 +64,9 @@ class EmbedlyControlPanelAdapter(SchemaAdapterBase):
 
     cache_timeout = property(getCacheTimeout,
                              setCacheTimeout)
+
+    service_blacklist = property(get_blacklist,
+                                set_blacklist)
 
 
 class EmbedlyControlPanel(ControlPanelForm):

--- a/collective/embedly/configure.zcml
+++ b/collective/embedly/configure.zcml
@@ -75,6 +75,15 @@
       sortkey="4"
       profile="collective.embedly:default"
       />
+  <genericsetup:upgradeStep
+      title="Add service blacklist to registry"
+      description=""
+      source="1004"
+      destination="1005"
+      handler="collective.embedly.setuphandlers.update_registry"
+      sortkey="4"
+      profile="collective.embedly:default"
+      />
   <utility
       factory=".setuphandlers.HiddenProfiles"
       name="collective.embedly"

--- a/collective/embedly/interfaces.py
+++ b/collective/embedly/interfaces.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from zope import schema
 from zope.interface import Interface
 from collective.embedly import embedlyMessageFactory as _
@@ -40,5 +41,16 @@ class IEmbedlySettings(Interface):
         title=_(u"Cache timeout"),
         description=_(u"Time is seconds to invalidate cache."),
         default=60 * 60 * 24,
+        required=False,
+    )
+
+    service_blacklist = schema.TextLine(
+        title=_(u"Services Blacklist"),
+        description=_(
+            u"Do not request oembed results for services matching this regex "
+            u"(e.g: 'http[s]?://(?:www\\.)?(?:youtu.be|youtube.com).*'"
+            u"to not replace youtube urls"
+        ),
+        default=u'',
         required=False,
     )

--- a/collective/embedly/locales/collective.embedly.pot
+++ b/collective/embedly/locales/collective.embedly.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2014-09-26 15:19+0000\n"
+"POT-Creation-Date: 2017-08-28 19:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/embedly/interfaces.py:12
+#: collective/embedly/interfaces.py:13
 msgid "API Key"
 msgstr ""
 
@@ -22,15 +22,19 @@ msgstr ""
 msgid "Advanced"
 msgstr ""
 
-#: collective/embedly/interfaces.py:40
+#: collective/embedly/interfaces.py:41
 msgid "Cache timeout"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:151
+#: collective/embedly/browser/plugin/embedly.pt:154
 msgid "Cancel"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:121
+#: collective/embedly/interfaces.py:49
+msgid "Do not request oembed results for services matching this regex (e.g: 'http[s]?://(?:www\.)?(?:youtu.be|youtube.com).*'to not replace youtube urls"
+msgstr ""
+
+#: collective/embedly/browser/plugin/embedly.pt:124
 msgid "Either true Embedly will use the video_src meta or Open Graph tag to create a video object to embed."
 msgstr ""
 
@@ -39,11 +43,11 @@ msgstr ""
 msgid "Embedly"
 msgstr ""
 
-#: collective/embedly/browser/controlpanel.py:65
+#: collective/embedly/browser/controlpanel.py:74
 msgid "Embedly settings"
 msgstr ""
 
-#: collective/embedly/interfaces.py:13
+#: collective/embedly/interfaces.py:14
 msgid "Enter the API key given to you by Embedly. It can be found by logging into Embedly and going to your dashboard."
 msgstr ""
 
@@ -51,143 +55,147 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:113
+#: collective/embedly/browser/plugin/embedly.pt:116
 msgid "Hide Related"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:93
+#: collective/embedly/browser/plugin/embedly.pt:96
 msgid "In some cases, you may need the script tag for saving and displaying later. In order for Embedly to send the script embeds over jsonp add allowscripts."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:150
+#: collective/embedly/browser/plugin/embedly.pt:153
 msgid "Insert"
 msgstr ""
 
-#: collective/embedly/browser/controlpanel.py:66
+#: collective/embedly/browser/controlpanel.py:75
 msgid "Lets you change the settings of collective.embedly"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:32
+#: collective/embedly/browser/plugin/embedly.pt:35
 msgid "Link URL"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:35
+#: collective/embedly/browser/plugin/embedly.pt:38
 msgid "Preview"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:74
+#: collective/embedly/interfaces.py:48
+msgid "Services Blacklist"
+msgstr ""
+
+#: collective/embedly/browser/plugin/embedly.pt:77
 msgid "The callback is the name of the javascript function to execute."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:128
+#: collective/embedly/browser/plugin/embedly.pt:131
 msgid "The words parameter has a default value of 50 and works by trying to split the description at the closest sentence to that word count."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:100
+#: collective/embedly/browser/plugin/embedly.pt:103
 msgid "These all have style elements and inline styles associated with them that make the embeds look good. If you wish to style these embeds yourself, you can add nostyle and Embedly will remove the style elements."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:60
+#: collective/embedly/browser/plugin/embedly.pt:63
 msgid "This is the maximum height of the embed in pixels."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:53
+#: collective/embedly/browser/plugin/embedly.pt:56
 msgid "This is the maximum width of the embed in pixels."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:114
+#: collective/embedly/browser/plugin/embedly.pt:117
 msgid "This will tell Embedly to not show related videos when the youtube video ended."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:107
+#: collective/embedly/browser/plugin/embedly.pt:110
 msgid "This will tell the video/rich media to automatically play when the media is loaded."
 msgstr ""
 
-#: collective/embedly/interfaces.py:41
+#: collective/embedly/interfaces.py:42
 msgid "Time is seconds to invalidate cache."
 msgstr ""
 
-#: collective/embedly/interfaces.py:22
+#: collective/embedly/interfaces.py:23
 msgid "Use Embedly Services API for checking url before getting oembed result."
 msgstr ""
 
-#: collective/embedly/interfaces.py:31
+#: collective/embedly/interfaces.py:32
 msgid "Use persistent cache"
 msgstr ""
 
-#: collective/embedly/interfaces.py:32
+#: collective/embedly/interfaces.py:33
 msgid "Use persistent cache for Embedly Services API call's responses."
 msgstr ""
 
-#: collective/embedly/interfaces.py:21
+#: collective/embedly/interfaces.py:22
 msgid "Use services regexp"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:81
+#: collective/embedly/browser/plugin/embedly.pt:84
 msgid "Will append the wmode value to the flash object."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:67
+#: collective/embedly/browser/plugin/embedly.pt:70
 msgid "Will scale embeds type rich and video to the exact width that a developer specifies in pixels."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:92
+#: collective/embedly/browser/plugin/embedly.pt:95
 msgid "allowscripts"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:106
+#: collective/embedly/browser/plugin/embedly.pt:109
 msgid "autoplay"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:73
+#: collective/embedly/browser/plugin/embedly.pt:76
 msgid "callback"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:136
+#: collective/embedly/browser/plugin/embedly.pt:139
 msgid "chars"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:137
+#: collective/embedly/browser/plugin/embedly.pt:140
 msgid "chars is much simpler than words. Embedly will blindly truncate a description to the number of characters you specify adding ... at the end when needed."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:59
+#: collective/embedly/browser/plugin/embedly.pt:62
 msgid "maxheight"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:52
+#: collective/embedly/browser/plugin/embedly.pt:55
 msgid "maxwidth"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:99
+#: collective/embedly/browser/plugin/embedly.pt:102
 msgid "nostyle"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:86
+#: collective/embedly/browser/plugin/embedly.pt:89
 msgid "opaque"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:87
+#: collective/embedly/browser/plugin/embedly.pt:90
 msgid "transparent"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:120
+#: collective/embedly/browser/plugin/embedly.pt:123
 msgid "videosrc"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:66
+#: collective/embedly/browser/plugin/embedly.pt:69
 msgid "width"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:85
+#: collective/embedly/browser/plugin/embedly.pt:88
 msgid "window"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:80
+#: collective/embedly/browser/plugin/embedly.pt:83
 msgid "wmode"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:127
+#: collective/embedly/browser/plugin/embedly.pt:130
 msgid "words"
 msgstr ""
 

--- a/collective/embedly/locales/de/LC_MESSAGES/collective.embedly.po
+++ b/collective/embedly/locales/de/LC_MESSAGES/collective.embedly.po
@@ -1,9 +1,9 @@
-# Harald Friessnegger <harald@webmeisterei.com>, 2014.
+# Harald Friessnegger <harald@webmeisterei.com>, 2014, 2017.
 msgid ""
 msgstr ""
 "Project-Id-Version: 2.3\n"
-"POT-Creation-Date: 2014-09-26 15:19+0000\n"
-"PO-Revision-Date: 2014-09-26 22:40+0200\n"
+"POT-Creation-Date: 2017-08-28 19:54+0000\n"
+"PO-Revision-Date: 2017-08-28 21:57+0100\n"
 "Last-Translator: Harald Friessnegger <harald@webmeisterei.com>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
@@ -14,10 +14,10 @@ msgstr ""
 "Language-Name: German\n"
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.embedly\n"
-"X-Generator: Lokalize 1.5\n"
+"X-Generator: Lokalize 2.0\n"
 "Language: de\n"
 
-#: collective/embedly/interfaces.py:12
+#: collective/embedly/interfaces.py:13
 msgid "API Key"
 msgstr "API Schlüssel"
 
@@ -25,15 +25,24 @@ msgstr "API Schlüssel"
 msgid "Advanced"
 msgstr "Fortgeschritten"
 
-#: collective/embedly/interfaces.py:40
+#: collective/embedly/interfaces.py:41
 msgid "Cache timeout"
 msgstr "Vorhaltezeit für den Cache"
 
-#: collective/embedly/browser/plugin/embedly.pt:151
+#: collective/embedly/browser/plugin/embedly.pt:154
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: collective/embedly/browser/plugin/embedly.pt:121
+#: collective/embedly/interfaces.py:49
+msgid ""
+"Do not request oembed results for services matching this regex (e.g: "
+"'http[s]?://(?:www\.)?(?:youtu.be|youtube.com).*'to not replace youtube urls"
+msgstr ""
+"Keine API-Anfrage für URLs abschicken die diesem Regulären Ausdruck "
+"entsprechen. (z.B 'http[s]?://(?:www\.)?(?:youtu.be|youtube.com).*' um "
+"Youtube auszuchließen) "
+
+#: collective/embedly/browser/plugin/embedly.pt:124
 msgid ""
 "Either true Embedly will use the video_src meta or Open Graph tag to create a "
 "video object to embed."
@@ -44,11 +53,11 @@ msgstr ""
 msgid "Embedly"
 msgstr "Embedly"
 
-#: collective/embedly/browser/controlpanel.py:65
+#: collective/embedly/browser/controlpanel.py:74
 msgid "Embedly settings"
 msgstr "Embedly Einstellungen"
 
-#: collective/embedly/interfaces.py:13
+#: collective/embedly/interfaces.py:14
 msgid ""
 "Enter the API key given to you by Embedly. It can be found by logging into "
 "Embedly and going to your dashboard."
@@ -60,37 +69,41 @@ msgstr ""
 msgid "General"
 msgstr "Standard"
 
-#: collective/embedly/browser/plugin/embedly.pt:113
+#: collective/embedly/browser/plugin/embedly.pt:116
 msgid "Hide Related"
 msgstr "Verwandte Videos nicht anzeigen"
 
-#: collective/embedly/browser/plugin/embedly.pt:93
+#: collective/embedly/browser/plugin/embedly.pt:96
 msgid ""
 "In some cases, you may need the script tag for saving and displaying later. "
 "In order for Embedly to send the script embeds over jsonp add allowscripts."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:150
+#: collective/embedly/browser/plugin/embedly.pt:153
 msgid "Insert"
 msgstr "Einfügen"
 
-#: collective/embedly/browser/controlpanel.py:66
+#: collective/embedly/browser/controlpanel.py:75
 msgid "Lets you change the settings of collective.embedly"
 msgstr "Hier können sie die Einstellungen für collective.embedly anpassen."
 
-#: collective/embedly/browser/plugin/embedly.pt:32
+#: collective/embedly/browser/plugin/embedly.pt:35
 msgid "Link URL"
 msgstr "Einzubindende Adresse"
 
-#: collective/embedly/browser/plugin/embedly.pt:35
+#: collective/embedly/browser/plugin/embedly.pt:38
 msgid "Preview"
 msgstr "Vorschau"
 
-#: collective/embedly/browser/plugin/embedly.pt:74
+#: collective/embedly/interfaces.py:48
+msgid "Services Blacklist"
+msgstr "Service Blacklist"
+
+#: collective/embedly/browser/plugin/embedly.pt:77
 msgid "The callback is the name of the javascript function to execute."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:128
+#: collective/embedly/browser/plugin/embedly.pt:131
 msgid ""
 "The words parameter has a default value of 50 and works by trying to split "
 "the description at the closest sentence to that word count."
@@ -98,22 +111,22 @@ msgstr ""
 "Den Beschreibungstext nach [Anzahl] Worten am nächstgelegenen Satzende "
 "abschneiden. (Standardwert: 50)"
 
-#: collective/embedly/browser/plugin/embedly.pt:100
+#: collective/embedly/browser/plugin/embedly.pt:103
 msgid ""
 "These all have style elements and inline styles associated with them that "
 "make the embeds look good. If you wish to style these embeds yourself, you "
 "can add nostyle and Embedly will remove the style elements."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:60
+#: collective/embedly/browser/plugin/embedly.pt:63
 msgid "This is the maximum height of the embed in pixels."
 msgstr "Maximale Höhe des eingebetteten Objektes in Pixeln."
 
-#: collective/embedly/browser/plugin/embedly.pt:53
+#: collective/embedly/browser/plugin/embedly.pt:56
 msgid "This is the maximum width of the embed in pixels."
 msgstr "Maximale Breite des eingebetteten Objektes in Pixeln."
 
-#: collective/embedly/browser/plugin/embedly.pt:114
+#: collective/embedly/browser/plugin/embedly.pt:117
 msgid ""
 "This will tell Embedly to not show related videos when the youtube video "
 "ended."
@@ -121,64 +134,64 @@ msgstr ""
 "Wenn ausgewählt, nach dem Abspielen eines Youtube Videos keine ähnlichen "
 "Videos anzeigen."
 
-#: collective/embedly/browser/plugin/embedly.pt:107
+#: collective/embedly/browser/plugin/embedly.pt:110
 msgid ""
 "This will tell the video/rich media to automatically play when the media is "
 "loaded."
 msgstr ""
 "Videos und andere Medieninhalte werden nach dem Laden automatisch abgespielt."
 
-#: collective/embedly/interfaces.py:41
+#: collective/embedly/interfaces.py:42
 msgid "Time is seconds to invalidate cache."
 msgstr "Zeitangabe in Sekunden."
 
-#: collective/embedly/interfaces.py:22
+#: collective/embedly/interfaces.py:23
 msgid "Use Embedly Services API for checking url before getting oembed result."
 msgstr ""
-"Verwende die Embedly Service API um zu prüfen ob die URL unterstütz wird "
+"Verwende die Embedly Service API um zu prüfen ob die URL unterstützt wird "
 "bevor ein Resultat von oembed angefordert wird."
 
-#: collective/embedly/interfaces.py:31
+#: collective/embedly/interfaces.py:32
 msgid "Use persistent cache"
 msgstr "Persistenten Cache verwenden"
 
-#: collective/embedly/interfaces.py:32
+#: collective/embedly/interfaces.py:33
 msgid "Use persistent cache for Embedly Services API call's responses."
 msgstr ""
 "Speichert Antworten auf die Embedly Service API in der Datenbank anstatt nur "
 "im RAM."
 
-#: collective/embedly/interfaces.py:21
+#: collective/embedly/interfaces.py:22
 msgid "Use services regexp"
 msgstr "Services validieren"
 
-#: collective/embedly/browser/plugin/embedly.pt:81
+#: collective/embedly/browser/plugin/embedly.pt:84
 msgid "Will append the wmode value to the flash object."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:67
+#: collective/embedly/browser/plugin/embedly.pt:70
 msgid ""
 "Will scale embeds type rich and video to the exact width that a developer "
 "specifies in pixels."
 msgstr "Skaliert eingebundene Objekte exakt auf die in Pixel angegeben Breite."
 
-#: collective/embedly/browser/plugin/embedly.pt:92
+#: collective/embedly/browser/plugin/embedly.pt:95
 msgid "allowscripts"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:106
+#: collective/embedly/browser/plugin/embedly.pt:109
 msgid "autoplay"
 msgstr "Automatisch Abspielen"
 
-#: collective/embedly/browser/plugin/embedly.pt:73
+#: collective/embedly/browser/plugin/embedly.pt:76
 msgid "callback"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:136
+#: collective/embedly/browser/plugin/embedly.pt:139
 msgid "chars"
 msgstr "Zeichen"
 
-#: collective/embedly/browser/plugin/embedly.pt:137
+#: collective/embedly/browser/plugin/embedly.pt:140
 msgid ""
 "chars is much simpler than words. Embedly will blindly truncate a description "
 "to the number of characters you specify adding ... at the end when needed."
@@ -186,43 +199,43 @@ msgstr ""
 "Im Gegensatz zu Worte, schneidet Embedly den Beschreibungstext einfach nach "
 "[Anzahl] Zeichen ab und fügt wenn nötig am Ende ein ... ein."
 
-#: collective/embedly/browser/plugin/embedly.pt:59
+#: collective/embedly/browser/plugin/embedly.pt:62
 msgid "maxheight"
 msgstr "Maximale Höhe"
 
-#: collective/embedly/browser/plugin/embedly.pt:52
+#: collective/embedly/browser/plugin/embedly.pt:55
 msgid "maxwidth"
 msgstr "Maximale Breite"
 
-#: collective/embedly/browser/plugin/embedly.pt:99
+#: collective/embedly/browser/plugin/embedly.pt:102
 msgid "nostyle"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:86
+#: collective/embedly/browser/plugin/embedly.pt:89
 msgid "opaque"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:87
+#: collective/embedly/browser/plugin/embedly.pt:90
 msgid "transparent"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:120
+#: collective/embedly/browser/plugin/embedly.pt:123
 msgid "videosrc"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:66
+#: collective/embedly/browser/plugin/embedly.pt:69
 msgid "width"
 msgstr "Breite"
 
-#: collective/embedly/browser/plugin/embedly.pt:85
+#: collective/embedly/browser/plugin/embedly.pt:88
 msgid "window"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:80
+#: collective/embedly/browser/plugin/embedly.pt:83
 msgid "wmode"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:127
+#: collective/embedly/browser/plugin/embedly.pt:130
 msgid "words"
 msgstr "Worte"
 

--- a/collective/embedly/locales/pt_BR/LC_MESSAGES/collective.embedly.po
+++ b/collective/embedly/locales/pt_BR/LC_MESSAGES/collective.embedly.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 2.3\n"
-"POT-Creation-Date: 2014-09-26 15:19+0000\n"
+"POT-Creation-Date: 2017-08-28 19:54+0000\n"
 "PO-Revision-Date: 2014-04-30 10:38-0300\n"
 "Last-Translator: Gustavo Lepri <gustavolepri@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Domain: collective.embedly\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: collective/embedly/interfaces.py:12
+#: collective/embedly/interfaces.py:13
 msgid "API Key"
 msgstr "API Key"
 
@@ -23,15 +23,19 @@ msgstr "API Key"
 msgid "Advanced"
 msgstr "Avançado"
 
-#: collective/embedly/interfaces.py:40
+#: collective/embedly/interfaces.py:41
 msgid "Cache timeout"
 msgstr "Tempo limite do cache"
 
-#: collective/embedly/browser/plugin/embedly.pt:151
+#: collective/embedly/browser/plugin/embedly.pt:154
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: collective/embedly/browser/plugin/embedly.pt:121
+#: collective/embedly/interfaces.py:49
+msgid "Do not request oembed results for services matching this regex (e.g: 'http[s]?://(?:www\.)?(?:youtu.be|youtube.com).*'to not replace youtube urls"
+msgstr ""
+
+#: collective/embedly/browser/plugin/embedly.pt:124
 msgid "Either true Embedly will use the video_src meta or Open Graph tag to create a video object to embed."
 msgstr "Caso verdadeiro, o Embedly irá usar o meta video_src ou a tag Open Graph para criar um objeto video para embutir."
 
@@ -40,11 +44,11 @@ msgstr "Caso verdadeiro, o Embedly irá usar o meta video_src ou a tag Open Grap
 msgid "Embedly"
 msgstr "Embedly"
 
-#: collective/embedly/browser/controlpanel.py:65
+#: collective/embedly/browser/controlpanel.py:74
 msgid "Embedly settings"
 msgstr "Configurações do Embedly"
 
-#: collective/embedly/interfaces.py:13
+#: collective/embedly/interfaces.py:14
 msgid "Enter the API key given to you by Embedly. It can be found by logging into Embedly and going to your dashboard."
 msgstr "Insira a chave da API fornecida pelo Embedly. Ela pode ser encontrada entrando em Embedly e indo para seu painel."
 
@@ -52,143 +56,147 @@ msgstr "Insira a chave da API fornecida pelo Embedly. Ela pode ser encontrada en
 msgid "General"
 msgstr "Geral"
 
-#: collective/embedly/browser/plugin/embedly.pt:113
+#: collective/embedly/browser/plugin/embedly.pt:116
 msgid "Hide Related"
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:93
+#: collective/embedly/browser/plugin/embedly.pt:96
 msgid "In some cases, you may need the script tag for saving and displaying later. In order for Embedly to send the script embeds over jsonp add allowscripts."
 msgstr "Em alguns casos, você pode precisar da tag script para salvar e exibir mais tarde. A fim de que o Embedly possa enviar o script integrado sobre jsonp, adicionar allowscripts."
 
-#: collective/embedly/browser/plugin/embedly.pt:150
+#: collective/embedly/browser/plugin/embedly.pt:153
 msgid "Insert"
 msgstr "Inserir"
 
-#: collective/embedly/browser/controlpanel.py:66
+#: collective/embedly/browser/controlpanel.py:75
 msgid "Lets you change the settings of collective.embedly"
 msgstr "Permite a alteração das configurações do collective.embedly"
 
-#: collective/embedly/browser/plugin/embedly.pt:32
+#: collective/embedly/browser/plugin/embedly.pt:35
 msgid "Link URL"
 msgstr "URL do Link"
 
-#: collective/embedly/browser/plugin/embedly.pt:35
+#: collective/embedly/browser/plugin/embedly.pt:38
 msgid "Preview"
 msgstr "Visualização"
 
-#: collective/embedly/browser/plugin/embedly.pt:74
+#: collective/embedly/interfaces.py:48
+msgid "Services Blacklist"
+msgstr ""
+
+#: collective/embedly/browser/plugin/embedly.pt:77
 msgid "The callback is the name of the javascript function to execute."
 msgstr "O callback é o nome da função javascript a ser executada."
 
-#: collective/embedly/browser/plugin/embedly.pt:128
+#: collective/embedly/browser/plugin/embedly.pt:131
 msgid "The words parameter has a default value of 50 and works by trying to split the description at the closest sentence to that word count."
 msgstr "O parâmetro palavras tem um valor padrão de 50 e trabalha tentando dividir a descrição a uma sentença mais próxima à contagem de palavras."
 
-#: collective/embedly/browser/plugin/embedly.pt:100
+#: collective/embedly/browser/plugin/embedly.pt:103
 msgid "These all have style elements and inline styles associated with them that make the embeds look good. If you wish to style these embeds yourself, you can add nostyle and Embedly will remove the style elements."
 msgstr "Todos esses tem elementos de estilo e estilos inline associados a eles que fazem com que as incorporações (embeds) tenham boa aparência. Se você deseja estilizar estas incorporações (embeds), você pode addionar nostyle e o Embedly irá remover todos os elementos de estilo."
 
-#: collective/embedly/browser/plugin/embedly.pt:60
+#: collective/embedly/browser/plugin/embedly.pt:63
 msgid "This is the maximum height of the embed in pixels."
 msgstr "Este é o valor da altura máxima em pixels."
 
-#: collective/embedly/browser/plugin/embedly.pt:53
+#: collective/embedly/browser/plugin/embedly.pt:56
 msgid "This is the maximum width of the embed in pixels."
 msgstr "Este é o valor da largura máxima em pixels."
 
-#: collective/embedly/browser/plugin/embedly.pt:114
+#: collective/embedly/browser/plugin/embedly.pt:117
 msgid "This will tell Embedly to not show related videos when the youtube video ended."
 msgstr ""
 
-#: collective/embedly/browser/plugin/embedly.pt:107
+#: collective/embedly/browser/plugin/embedly.pt:110
 msgid "This will tell the video/rich media to automatically play when the media is loaded."
 msgstr "Isto diz ao video/conteúdo de mídia para iniciar a reprodução automaticamente quando a mídia for carregada."
 
-#: collective/embedly/interfaces.py:41
+#: collective/embedly/interfaces.py:42
 msgid "Time is seconds to invalidate cache."
 msgstr "Segundos para invalidar o cache."
 
-#: collective/embedly/interfaces.py:22
+#: collective/embedly/interfaces.py:23
 msgid "Use Embedly Services API for checking url before getting oembed result."
 msgstr "Utilizar a API de Serviços do Embedly para verificar a url antes de obter o resultado oembed."
 
-#: collective/embedly/interfaces.py:31
+#: collective/embedly/interfaces.py:32
 msgid "Use persistent cache"
 msgstr "Utilizar cache persistente"
 
-#: collective/embedly/interfaces.py:32
+#: collective/embedly/interfaces.py:33
 msgid "Use persistent cache for Embedly Services API call's responses."
 msgstr "Utilizar cache persistente para as respostas de chamadas à API de Serviços do Embedly."
 
-#: collective/embedly/interfaces.py:21
+#: collective/embedly/interfaces.py:22
 msgid "Use services regexp"
 msgstr "Usar serviços regexp"
 
-#: collective/embedly/browser/plugin/embedly.pt:81
+#: collective/embedly/browser/plugin/embedly.pt:84
 msgid "Will append the wmode value to the flash object."
 msgstr "Irá adicionar o valor wmode ao objeto flash."
 
-#: collective/embedly/browser/plugin/embedly.pt:67
+#: collective/embedly/browser/plugin/embedly.pt:70
 msgid "Will scale embeds type rich and video to the exact width that a developer specifies in pixels."
 msgstr "Irá escalar o conteúdo de mídia/video para o tamanho exato da largura, em pixels, especificado pelo desenvolvedor."
 
-#: collective/embedly/browser/plugin/embedly.pt:92
+#: collective/embedly/browser/plugin/embedly.pt:95
 msgid "allowscripts"
 msgstr "allowscripts"
 
-#: collective/embedly/browser/plugin/embedly.pt:106
+#: collective/embedly/browser/plugin/embedly.pt:109
 msgid "autoplay"
 msgstr "autoplay"
 
-#: collective/embedly/browser/plugin/embedly.pt:73
+#: collective/embedly/browser/plugin/embedly.pt:76
 msgid "callback"
 msgstr "callback"
 
-#: collective/embedly/browser/plugin/embedly.pt:136
+#: collective/embedly/browser/plugin/embedly.pt:139
 msgid "chars"
 msgstr "caracteres"
 
-#: collective/embedly/browser/plugin/embedly.pt:137
+#: collective/embedly/browser/plugin/embedly.pt:140
 msgid "chars is much simpler than words. Embedly will blindly truncate a description to the number of characters you specify adding ... at the end when needed."
 msgstr "caracteres é muito mais simples do que palavras. O Embedly irá, cegamente, truncar uma descrição para o número de caracteres que você especificar adicionando ... ao final quando necessário."
 
-#: collective/embedly/browser/plugin/embedly.pt:59
+#: collective/embedly/browser/plugin/embedly.pt:62
 msgid "maxheight"
 msgstr "maxheight"
 
-#: collective/embedly/browser/plugin/embedly.pt:52
+#: collective/embedly/browser/plugin/embedly.pt:55
 msgid "maxwidth"
 msgstr "maxwidth"
 
-#: collective/embedly/browser/plugin/embedly.pt:99
+#: collective/embedly/browser/plugin/embedly.pt:102
 msgid "nostyle"
 msgstr "nostyle"
 
-#: collective/embedly/browser/plugin/embedly.pt:86
+#: collective/embedly/browser/plugin/embedly.pt:89
 msgid "opaque"
 msgstr "opaque"
 
-#: collective/embedly/browser/plugin/embedly.pt:87
+#: collective/embedly/browser/plugin/embedly.pt:90
 msgid "transparent"
 msgstr "transparent"
 
-#: collective/embedly/browser/plugin/embedly.pt:120
+#: collective/embedly/browser/plugin/embedly.pt:123
 msgid "videosrc"
 msgstr "videosrc"
 
-#: collective/embedly/browser/plugin/embedly.pt:66
+#: collective/embedly/browser/plugin/embedly.pt:69
 msgid "width"
 msgstr "largura"
 
-#: collective/embedly/browser/plugin/embedly.pt:85
+#: collective/embedly/browser/plugin/embedly.pt:88
 msgid "window"
 msgstr "janela"
 
-#: collective/embedly/browser/plugin/embedly.pt:80
+#: collective/embedly/browser/plugin/embedly.pt:83
 msgid "wmode"
 msgstr "wmode"
 
-#: collective/embedly/browser/plugin/embedly.pt:127
+#: collective/embedly/browser/plugin/embedly.pt:130
 msgid "words"
 msgstr "palavras"
 

--- a/collective/embedly/locales/uk/LC_MESSAGES/collective.embedly.po
+++ b/collective/embedly/locales/uk/LC_MESSAGES/collective.embedly.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 2.3\n"
-"POT-Creation-Date: 2014-09-26 15:19+0000\n"
+"POT-Creation-Date: 2017-08-28 19:54+0000\n"
 "PO-Revision-Date: 2015-10-07 17:19+0300\n"
 "Last-Translator: Zoriana Zaiats <sorenabell@quintagroup.com>\n"
 "Language-Team: Ukrainian <support@quintagroup.com>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Generator: Lokalize 1.5\n"
 "Language: uk\n"
 
-#: collective/embedly/interfaces.py:12
+#: collective/embedly/interfaces.py:13
 msgid "API Key"
 msgstr "Ключ API"
 
@@ -25,215 +25,180 @@ msgstr "Ключ API"
 msgid "Advanced"
 msgstr "Розширені налаштування"
 
-#: collective/embedly/interfaces.py:40
+#: collective/embedly/interfaces.py:41
 msgid "Cache timeout"
 msgstr "Тайм-аут кешу"
 
-#: collective/embedly/browser/plugin/embedly.pt:151
+#: collective/embedly/browser/plugin/embedly.pt:154
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: collective/embedly/browser/plugin/embedly.pt:121
-msgid ""
-"Either true Embedly will use the video_src meta or Open Graph tag to create a "
-"video object to embed."
+#: collective/embedly/interfaces.py:49
+msgid "Do not request oembed results for services matching this regex (e.g: 'http[s]?://(?:www\.)?(?:youtu.be|youtube.com).*'to not replace youtube urls"
 msgstr ""
-"Embedly використає або video_src meta, або Open Graph тег для створення відео "
-"об’єкта для вставки."
+
+#: collective/embedly/browser/plugin/embedly.pt:124
+msgid "Either true Embedly will use the video_src meta or Open Graph tag to create a video object to embed."
+msgstr "Embedly використає або video_src meta, або Open Graph тег для створення відео об’єкта для вставки."
 
 #: collective/embedly/browser/plugin/embedly.pt:6
 #: collective/embedly/profiles/default/controlpanel.xml
 msgid "Embedly"
 msgstr "Embedly"
 
-#: collective/embedly/browser/controlpanel.py:65
+#: collective/embedly/browser/controlpanel.py:74
 msgid "Embedly settings"
 msgstr "Налаштування Embedly"
 
-#: collective/embedly/interfaces.py:13
-msgid ""
-"Enter the API key given to you by Embedly. It can be found by logging into "
-"Embedly and going to your dashboard."
-msgstr ""
-"Введіть API ключ наданий вам сервісом Embedly. Його можна знайти, "
-"залогувавшись в Embedly та перейшовши на панель керування (Dashboard)."
+#: collective/embedly/interfaces.py:14
+msgid "Enter the API key given to you by Embedly. It can be found by logging into Embedly and going to your dashboard."
+msgstr "Введіть API ключ наданий вам сервісом Embedly. Його можна знайти, залогувавшись в Embedly та перейшовши на панель керування (Dashboard)."
 
 #: collective/embedly/browser/plugin/embedly.pt:18
 msgid "General"
 msgstr "Загальні налаштування"
 
-#: collective/embedly/browser/plugin/embedly.pt:113
+#: collective/embedly/browser/plugin/embedly.pt:116
 msgid "Hide Related"
 msgstr "Сховати пов’язані"
 
-#: collective/embedly/browser/plugin/embedly.pt:93
-msgid ""
-"In some cases, you may need the script tag for saving and displaying later. "
-"In order for Embedly to send the script embeds over jsonp add allowscripts."
-msgstr ""
-"У деяких випадках вам знадобиться скрипт тег для зберігання та відображення. "
-"Для того, щоб сервіс Embedly посилав вставки скрипта через jsonp, додайте "
-"allowscripts."
+#: collective/embedly/browser/plugin/embedly.pt:96
+msgid "In some cases, you may need the script tag for saving and displaying later. In order for Embedly to send the script embeds over jsonp add allowscripts."
+msgstr "У деяких випадках вам знадобиться скрипт тег для зберігання та відображення. Для того, щоб сервіс Embedly посилав вставки скрипта через jsonp, додайте allowscripts."
 
-#: collective/embedly/browser/plugin/embedly.pt:150
+#: collective/embedly/browser/plugin/embedly.pt:153
 msgid "Insert"
 msgstr "Вставити"
 
-#: collective/embedly/browser/controlpanel.py:66
+#: collective/embedly/browser/controlpanel.py:75
 msgid "Lets you change the settings of collective.embedly"
 msgstr "Дозволяє змінити налаштування collective.embedly"
 
-#: collective/embedly/browser/plugin/embedly.pt:32
+#: collective/embedly/browser/plugin/embedly.pt:35
 msgid "Link URL"
 msgstr "URL-адреса посилання"
 
-#: collective/embedly/browser/plugin/embedly.pt:35
+#: collective/embedly/browser/plugin/embedly.pt:38
 msgid "Preview"
 msgstr "Попередній перегляд"
 
-#: collective/embedly/browser/plugin/embedly.pt:74
+#: collective/embedly/interfaces.py:48
+msgid "Services Blacklist"
+msgstr ""
+
+#: collective/embedly/browser/plugin/embedly.pt:77
 msgid "The callback is the name of the javascript function to execute."
-msgstr ""
-"Зворотній виклик (callback) - це назва javascript функції для виконання."
+msgstr "Зворотній виклик (callback) - це назва javascript функції для виконання."
 
-#: collective/embedly/browser/plugin/embedly.pt:128
-msgid ""
-"The words parameter has a default value of 50 and works by trying to split "
-"the description at the closest sentence to that word count."
-msgstr ""
-"Парамерт \"words\" має стандартне значення 50. Опис розділяється на реченні, "
-"найближчому до цієї кількості слів."
+#: collective/embedly/browser/plugin/embedly.pt:131
+msgid "The words parameter has a default value of 50 and works by trying to split the description at the closest sentence to that word count."
+msgstr "Парамерт \"words\" має стандартне значення 50. Опис розділяється на реченні, найближчому до цієї кількості слів."
 
-#: collective/embedly/browser/plugin/embedly.pt:100
-msgid ""
-"These all have style elements and inline styles associated with them that "
-"make the embeds look good. If you wish to style these embeds yourself, you "
-"can add nostyle and Embedly will remove the style elements."
-msgstr ""
-"Відео має елементи стилю та вбудовані стилі, пов'язані з ним, які надають "
-"вставці гарного вигляду. Якщо ви хочете додати стилі власноруч, ви можете "
-"додати nostyle параметр і Embedly видалить всі елементи стилю."
+#: collective/embedly/browser/plugin/embedly.pt:103
+msgid "These all have style elements and inline styles associated with them that make the embeds look good. If you wish to style these embeds yourself, you can add nostyle and Embedly will remove the style elements."
+msgstr "Відео має елементи стилю та вбудовані стилі, пов'язані з ним, які надають вставці гарного вигляду. Якщо ви хочете додати стилі власноруч, ви можете додати nostyle параметр і Embedly видалить всі елементи стилю."
 
-#: collective/embedly/browser/plugin/embedly.pt:60
+#: collective/embedly/browser/plugin/embedly.pt:63
 msgid "This is the maximum height of the embed in pixels."
 msgstr "Це максимальна висота вставки в пікселях."
 
-#: collective/embedly/browser/plugin/embedly.pt:53
+#: collective/embedly/browser/plugin/embedly.pt:56
 msgid "This is the maximum width of the embed in pixels."
 msgstr "Це максимальна ширина вставки в пікселях."
 
-#: collective/embedly/browser/plugin/embedly.pt:114
-msgid ""
-"This will tell Embedly to not show related videos when the youtube video "
-"ended."
-msgstr ""
-"Цей параметр дозволить не показувати пов’язані відео, коли youtube відео "
-"завершується."
+#: collective/embedly/browser/plugin/embedly.pt:117
+msgid "This will tell Embedly to not show related videos when the youtube video ended."
+msgstr "Цей параметр дозволить не показувати пов’язані відео, коли youtube відео завершується."
 
-#: collective/embedly/browser/plugin/embedly.pt:107
-msgid ""
-"This will tell the video/rich media to automatically play when the media is "
-"loaded."
-msgstr ""
-"Цей параметр дозволить програвати відео/мультимедіа автоматично при "
-"завантаженні."
+#: collective/embedly/browser/plugin/embedly.pt:110
+msgid "This will tell the video/rich media to automatically play when the media is loaded."
+msgstr "Цей параметр дозволить програвати відео/мультимедіа автоматично при завантаженні."
 
-#: collective/embedly/interfaces.py:41
+#: collective/embedly/interfaces.py:42
 msgid "Time is seconds to invalidate cache."
 msgstr "Час в секундах, щоб анулювати кеш."
 
-#: collective/embedly/interfaces.py:22
+#: collective/embedly/interfaces.py:23
 msgid "Use Embedly Services API for checking url before getting oembed result."
-msgstr ""
-"Використовуйте Embedly Services API для перевірки URL, перш ніж отримати "
-"вставлений результат."
+msgstr "Використовуйте Embedly Services API для перевірки URL, перш ніж отримати вставлений результат."
 
-#: collective/embedly/interfaces.py:31
+#: collective/embedly/interfaces.py:32
 msgid "Use persistent cache"
 msgstr "Використовувати постійний кеш"
 
-#: collective/embedly/interfaces.py:32
+#: collective/embedly/interfaces.py:33
 msgid "Use persistent cache for Embedly Services API call's responses."
 msgstr "Використовувати постійний кеш для відповідей Embedly Services API"
 
-#: collective/embedly/interfaces.py:21
+#: collective/embedly/interfaces.py:22
 msgid "Use services regexp"
 msgstr "Використовувати сервіси regexp"
 
-#: collective/embedly/browser/plugin/embedly.pt:81
+#: collective/embedly/browser/plugin/embedly.pt:84
 msgid "Will append the wmode value to the flash object."
 msgstr "Вставить wmode значення у flash об’єкт."
 
-#: collective/embedly/browser/plugin/embedly.pt:67
-msgid ""
-"Will scale embeds type rich and video to the exact width that a developer "
-"specifies in pixels."
+#: collective/embedly/browser/plugin/embedly.pt:70
+msgid "Will scale embeds type rich and video to the exact width that a developer specifies in pixels."
 msgstr "Масштабує вставлене відео до ширини заданої у пікселях."
 
-#: collective/embedly/browser/plugin/embedly.pt:92
+#: collective/embedly/browser/plugin/embedly.pt:95
 msgid "allowscripts"
 msgstr "allowscripts"
 
-#: collective/embedly/browser/plugin/embedly.pt:106
+#: collective/embedly/browser/plugin/embedly.pt:109
 msgid "autoplay"
 msgstr "autoplay"
 
-#: collective/embedly/browser/plugin/embedly.pt:73
+#: collective/embedly/browser/plugin/embedly.pt:76
 msgid "callback"
 msgstr "callback"
 
-#: collective/embedly/browser/plugin/embedly.pt:136
+#: collective/embedly/browser/plugin/embedly.pt:139
 msgid "chars"
 msgstr "chars"
 
-#: collective/embedly/browser/plugin/embedly.pt:137
-msgid ""
-"chars is much simpler than words. Embedly will blindly truncate a description "
-"to the number of characters you specify adding ... at the end when needed."
-msgstr ""
-"Параметр \"chars\" простіший ніж параметр \"words\". Embedly просто обріже "
-"опис "
-"відповідно до кількості символів, яку ви вкажете, і додасть ... в кінці, якщо "
-"потрібно."
+#: collective/embedly/browser/plugin/embedly.pt:140
+msgid "chars is much simpler than words. Embedly will blindly truncate a description to the number of characters you specify adding ... at the end when needed."
+msgstr "Параметр \"chars\" простіший ніж параметр \"words\". Embedly просто обріже опис відповідно до кількості символів, яку ви вкажете, і додасть ... в кінці, якщо потрібно."
 
-#: collective/embedly/browser/plugin/embedly.pt:59
+#: collective/embedly/browser/plugin/embedly.pt:62
 msgid "maxheight"
 msgstr "maxheight"
 
-#: collective/embedly/browser/plugin/embedly.pt:52
+#: collective/embedly/browser/plugin/embedly.pt:55
 msgid "maxwidth"
 msgstr "maxwidth"
 
-#: collective/embedly/browser/plugin/embedly.pt:99
+#: collective/embedly/browser/plugin/embedly.pt:102
 msgid "nostyle"
 msgstr "nostyle"
 
-#: collective/embedly/browser/plugin/embedly.pt:86
+#: collective/embedly/browser/plugin/embedly.pt:89
 msgid "opaque"
 msgstr "opaque"
 
-#: collective/embedly/browser/plugin/embedly.pt:87
+#: collective/embedly/browser/plugin/embedly.pt:90
 msgid "transparent"
 msgstr "transparent"
 
-#: collective/embedly/browser/plugin/embedly.pt:120
+#: collective/embedly/browser/plugin/embedly.pt:123
 msgid "videosrc"
 msgstr "videosrc"
 
-#: collective/embedly/browser/plugin/embedly.pt:66
+#: collective/embedly/browser/plugin/embedly.pt:69
 msgid "width"
 msgstr "width"
 
-#: collective/embedly/browser/plugin/embedly.pt:85
+#: collective/embedly/browser/plugin/embedly.pt:88
 msgid "window"
 msgstr "window"
 
-#: collective/embedly/browser/plugin/embedly.pt:80
+#: collective/embedly/browser/plugin/embedly.pt:83
 msgid "wmode"
 msgstr "wmode"
 
-#: collective/embedly/browser/plugin/embedly.pt:127
+#: collective/embedly/browser/plugin/embedly.pt:130
 msgid "words"
 msgstr "words"
-
 

--- a/collective/embedly/profiles/default/metadata.xml
+++ b/collective/embedly/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1004</version>
+  <version>1005</version>
   <dependencies>
      <dependency>profile-plone.app.registry:default</dependency>
   </dependencies>

--- a/collective/embedly/transform.py
+++ b/collective/embedly/transform.py
@@ -181,6 +181,13 @@ def parse(text, doc=None):
     def replace(matchobj):
         url = matchobj.groupdict().get('url', None)
 
+        service_blacklist = get_embedly_settings('service_blacklist')
+        if service_blacklist:
+            if re.match(service_blacklist, url):
+                # url is blacklisted
+                logger.debug('skipping blacklisted url: ' + url)
+                return matchobj.group()
+
         # Not Something Embedly Handles
         if get_embedly_settings('use_services_regexp') and not match(url):
             return matchobj.group()

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,6 +4,11 @@ Changelog
 dev
 ---
 
+- Add new registry setting `service_blacklist` and to not request embed
+  code for matching urls. (e.g. to handle embeds for youtube via javascript
+  and save API calls for other services)
+  [fRiSi]
+
 - Don't attempt to decode unicode strings in transform.
   [alecm]
 


### PR DESCRIPTION
this allows to configure embedly to not request an embed code for urls matching a certain regex.
we're using this to safe API calls as embedly recently drastically limited the number of free api calls.
now we handle youtube via javascript and use embedly for other services.

(this replaces #24)