### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Check the README.txt_ inside of the package.
 .. image:: https://badge.fury.io/py/collective.embedly.svg
     	:target: http://badge.fury.io/py/collective.embedly
 
-.. image:: https://pypip.in/v/collective.embedly/badge.png
+.. image:: https://img.shields.io/pypi/v/collective.embedly.svg
 	:target: https://pypi.python.org/pypi/collective.embedly/
 	:alt: Downloads
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20collective-embedly))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `collective-embedly`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.